### PR TITLE
feat: home page enhancement

### DIFF
--- a/developer-test-template/src/components/common/card.jsx
+++ b/developer-test-template/src/components/common/card.jsx
@@ -4,7 +4,7 @@ function Card({ children, className = '' }) {
       className={`flex w-full max-w-[448px] flex-col items-center justify-center rounded-3xl bg-[#FFFBFB] p-8 shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)] ${className}`}
     >
       {children}
-      <span className="text-text-muted mt-6 text-xs">made with ❤ Ozcoding️</span>
+      <span className="text-text-muted text-xs">made with ❤ Ozcoding</span>
     </div>
   );
 }

--- a/developer-test-template/src/index.css
+++ b/developer-test-template/src/index.css
@@ -1,13 +1,5 @@
 @import 'tailwindcss';
 
-body {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 100vh;
-  background: linear-gradient(180deg, var(--color-bg-default) 0%, #ffffff 100%);
-}
-
 /* =========================================
    Primitive Colors
    ========================================= */

--- a/developer-test-template/src/layouts/RootLayout.jsx
+++ b/developer-test-template/src/layouts/RootLayout.jsx
@@ -2,8 +2,8 @@ import { Outlet } from 'react-router-dom';
 
 export default function RootLayout() {
   return (
-    <div className="bg-bg-default flex min-h-screen justify-center p-6">
-      <div className="w-full max-w-[520px]">
+    <div className="flex min-h-screen items-center justify-center bg-[linear-gradient(180deg,var(--color-bg-default)_0%,#ffffff_100%)]">
+      <div>
         <Outlet />
       </div>
     </div>

--- a/developer-test-template/src/main.jsx
+++ b/developer-test-template/src/main.jsx
@@ -1,10 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import './index.css';
 import App from './App.jsx';
+import './index.css';
 
 async function enableMocking() {
-  if (process.env.NODE_ENV !== 'development') {
+  if (import.meta.env.MODE !== 'development') {
     return;
   }
 

--- a/developer-test-template/src/pages/HomePage.jsx
+++ b/developer-test-template/src/pages/HomePage.jsx
@@ -1,15 +1,27 @@
 import hamster from '@/assets/icon.webp';
 import Card from '@/components/common/card';
+import { useNavigate } from 'react-router-dom';
+import SparkleIcon from '../assets/icons/SparkleIcon.svg?react';
+import Button from '../components/common/button';
 
 export default function HomePage() {
+  const navigate = useNavigate();
+
   return (
-    <>
-      {/* 예시, 컴포넌트 제작 완료 후 편집 예정 */}
-      <Card>
+    <Card className="gap-8">
+      <div className="flex flex-col items-center justify-center">
         <img className="h-32 w-32" src={hamster} alt="hamster" />
         <h3 className="mt-6 text-center text-2xl">나는 어떤 개발자일까?</h3>
         <p className="text-text-description mt-4">햄스터 개발자 유형 테스트</p>
-      </Card>
-    </>
+      </div>
+      <div className="bg-bg-default text-text-body w-full rounded-2xl p-4 text-center text-sm">
+        <p>✨ 5개의 질문으로 알아보는 </p>
+        <p>나의 개발자 성향</p>
+      </div>
+      <Button onClick={() => navigate('/test')}>
+        <SparkleIcon className="h-5 w-5 text-white" />
+        시작하기
+      </Button>
+    </Card>
   );
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-ignoredBuiltDependencies:
-  - esbuild


### PR DESCRIPTION
## 📌 관련 이슈
#18

## ✨ 변경 내용
 - 홈 페이지 UI 수정 및 레이아웃 정리
 - 시작하기 버튼에 테스트 페이지 라우팅 연결
 - SVG 아이콘(SVGR) 적용
 - 상위폴더에 있는 pnpm-workspace.yaml 파일 삭제
 - index.css body 스타일 제거 
 - card 컴포넌트 span 태그 mt 제거

## 📸 스크린샷(선택)
<img width="745" height="749" alt="스크린샷 2026-02-26 오후 5 09 43" src="https://github.com/user-attachments/assets/9eed025f-2a6c-4160-91f9-985c097dbe7c" />
<img width="606" height="362" alt="스크린샷 2026-02-26 오후 5 09 58" src="https://github.com/user-attachments/assets/407ebad8-c950-4358-a7c6-6c556f7ed976" />

## 📚 참고사항

