### PR TITLE
refactor: move API baseURL to env and modularize questions service (#41)

### DIFF
--- a/developer-test-template/src/api/services/index.js
+++ b/developer-test-template/src/api/services/index.js
@@ -1,1 +1,2 @@
+export * from './questions';
 export * from './result';

--- a/developer-test-template/src/api/services/questions.js
+++ b/developer-test-template/src/api/services/questions.js
@@ -1,0 +1,6 @@
+import instance from '../instance';
+
+export const getQuestionsByType = async () => {
+  const { data } = await instance.get('/api/questions');
+  return data;
+};

--- a/developer-test-template/src/hooks/queries/index.js
+++ b/developer-test-template/src/hooks/queries/index.js
@@ -1,15 +1,10 @@
+import { getQuestionsByType } from '@/api/services/questions';
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
-//api 호출
-export async function getQuestions() {
-  const { data } = await axios.get('http://localhost:3000/api/questions');
-  return data;
-}
 
 export const useQuestion = () => {
   return useQuery({
     queryKey: ['questions'],
-    queryFn: getQuestions,
+    queryFn: getQuestionsByType,
     staleTime: 5000,
   });
 };


### PR DESCRIPTION
## 📌 관련 이슈
Closes #41

## ✨ 변경 내용
- API baseURL을 환경 변수(.env) 기반으로 분리
- axios 인스턴스에서 env 값 사용하도록 리팩토링
- questions API를 별도 서비스 파일로 분리

## 📸 스크린샷(선택)


## 📚 참고사항

